### PR TITLE
feat: add usage examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ tmp_*.py
 
 # Local Configuration files
 config/
+
+# Local files
+*.wav
+*.bin

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Paper: https://arxiv.org/abs/2307.08720
 
 # Usage Guidance
 
+See [examples](./examples) for how to use the models.
+
 ## Downloading From Sources
 
 ### Crowd Recital

--- a/examples/with_faster_whisper.py
+++ b/examples/with_faster_whisper.py
@@ -1,0 +1,14 @@
+"""
+Example using faster-whisper with ctranslate2 backend for fast audio transcription.
+
+Run with:
+    pip install faster-whisper
+    python with_faster_whisper.py
+"""
+
+import faster_whisper
+model = faster_whisper.WhisperModel('ivrit-ai/whisper-large-v3-turbo-ct2')
+
+segs, _ = model.transcribe('audio.wav', language='he')
+text = ' '.join(s.text for s in segs)
+print(f'Transcribed text: {text}')

--- a/examples/with_stable_timestamps.py
+++ b/examples/with_stable_timestamps.py
@@ -1,0 +1,14 @@
+"""
+Example of Stable-ts with faster-whisper for fast and accurate transcription.
+
+Run with:
+    pip install -U 'stable-ts[fw]'
+    python with_stable_timestamps.py
+"""
+
+import stable_whisper
+
+model = stable_whisper.load_faster_whisper('ivrit-ai/whisper-large-v3-turbo-ct2')
+segs = model.transcribe('audio.wav', language='he') # Use word_timestamps=True for word-level timestamps
+for s in segs:
+    print(f'{s.start:.2f} - {s.end:.2f}: {s.text}')

--- a/examples/with_whisper_cpp.py
+++ b/examples/with_whisper_cpp.py
@@ -1,0 +1,17 @@
+"""
+Example of using whispercpp for fast and lightweight transcription.
+
+Download the model from Hugging Face:
+    wget https://huggingface.co/ivrit-ai/whisper-large-v3-turbo-ggml/resolve/main/ggml-model.bin
+
+Run with:
+    pip install pywhispercpp
+    python with_whisper_cpp.py
+"""
+
+from pywhispercpp.model import Model
+
+model = Model('./ggml-model.bin')
+segs = model.transcribe('audio.wav', language='he')
+text = ' '.join(segment.text for segment in segs)
+print(f'Transcribed text: {text}')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,11 @@
+[project]
+name = "ivrit-ai"
+version = "0.1.0"
+description = "ivrit.ai codebase"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
 [tool.black]
 line-length = 120
 


### PR DESCRIPTION
Added examples for ivrit.ai turbo with faster-whisper/stable-ts/whisper.cpp (tested on macOS M1).
Added `project` field to pyproject.toml (for astral-uv, etc).
Future: add whisper.cpp example with .txt/.md files, showing how to compile and run from source?
